### PR TITLE
UID Search Fix

### DIFF
--- a/src/sdk-client.ts
+++ b/src/sdk-client.ts
@@ -261,7 +261,7 @@ export class SDKClient {
         const api = new IdentitiesBetaApi(this.config)
 
         const requestParameters: IdentitiesBetaApiListIdentitiesRequest = {
-            filters: `alias eq "${uid}"`,
+            filters: `uid eq "${uid}"`,
         }
         const response = await api.listIdentities(requestParameters)
 


### PR DESCRIPTION
Searching by `alias` did not seem to work correctly during create account operations. Updating search parameter to `uid`